### PR TITLE
(maint) Add Puppet 8 to nightly unit tests

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -13,62 +13,62 @@ jobs:
 
     steps:
 
-    - name: "Checkout Source"
-      if: ${{ github.repository_owner == 'puppetlabs' }}
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        persist-credentials: false
+      - name: "Checkout Source"
+        if: ${{ github.repository_owner == 'puppetlabs' }}
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-    # We use the dev tools image here because the PDK image does not have the
-    # build tools necessary to compile native extensions.
-    - name: "PDK Release prep"
-      uses: docker://puppet/puppet-dev-tools:4.x
-      with:
-        args: 'pdk release prep --force --debug'
-      env:
-        CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # We use the dev tools image here because the PDK image does not have the
+      # build tools necessary to compile native extensions.
+      - name: "PDK Release prep"
+        uses: docker://puppet/puppet-dev-tools:4.x
+        with:
+          args: 'pdk release prep --force --debug'
+        env:
+          CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: "Get Version"
-      if: ${{ github.repository_owner == 'puppetlabs' }}
-      id: gv
-      run: |
-        echo "::set-output name=ver::$(jq --raw-output .version metadata.json)"
+      - name: "Get Version"
+        if: ${{ github.repository_owner == 'puppetlabs' }}
+        id: gv
+        run: |
+          echo "::set-output name=ver::$(jq --raw-output .version metadata.json)"
 
-    - name: "Check if a release is necessary"
-      if: ${{ github.repository_owner == 'puppetlabs' }}
-      id: check
-      run: |
-        git diff --quiet CHANGELOG.md && echo "::set-output name=release::false" || echo "::set-output name=release::true"
+      - name: "Check if a release is necessary"
+        if: ${{ github.repository_owner == 'puppetlabs' }}
+        id: check
+        run: |
+          git diff --quiet CHANGELOG.md && echo "::set-output name=release::false" || echo "::set-output name=release::true"
 
-    - name: "Commit changes"
-      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
-      run: |
-        git config --local user.email "${{ github.repository_owner }}@users.noreply.github.com"
-        git config --local user.name "GitHub Action"
-        git add .
-        git commit -m "Release prep v${{ steps.gv.outputs.ver }}"
+      - name: "Commit changes"
+        if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
+        run: |
+          git config --local user.email "${{ github.repository_owner }}@users.noreply.github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Release prep v${{ steps.gv.outputs.ver }}"
 
-    - name: Create Pull Request
-      id: cpr
-      uses: puppetlabs/peter-evans-create-pull-request@v3
-      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "Release prep v${{ steps.gv.outputs.ver }}"
-        branch: "release-prep"
-        delete-branch: true
-        title: "Release prep v${{ steps.gv.outputs.ver }}"
-        body: |
-          Automated release-prep through [pdk-templates](https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.github/workflows/auto_release.yml.erb) from commit ${{ github.sha }}. 
-          Please verify before merging:
-          - [ ] last [nightly](https://github.com/${{ github.repository }}/actions/workflows/nightly.yml) run is green
-          - [ ] [Changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) is readable and has no unlabeled pull requests
-          - [ ] Ensure the [changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) version and [metadata](https://github.com/${{ github.repository }}/blob/release-prep/metadata.json) version match
-        labels: "maintenance"
+      - name: Create Pull Request
+        id: cpr
+        uses: puppetlabs/peter-evans-create-pull-request@v3
+        if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Release prep v${{ steps.gv.outputs.ver }}"
+          branch: "release-prep"
+          delete-branch: true
+          title: "Release prep v${{ steps.gv.outputs.ver }}"
+          body: |
+            Automated release-prep through [pdk-templates](https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.github/workflows/auto_release.yml.erb) from commit ${{ github.sha }}.
+            Please verify before merging:
+            - [ ] last [nightly](https://github.com/${{ github.repository }}/actions/workflows/nightly.yml) run is green
+            - [ ] [Changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) is readable and has no unlabeled pull requests
+            - [ ] Ensure the [changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) version and [metadata](https://github.com/${{ github.repository }}/blob/release-prep/metadata.json) version match
+          labels: "maintenance"
 
-    - name: PR outputs
-      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
-      run: |
-        echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-        echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+      - name: PR outputs
+        if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
         uses: "ibiqlik/action-yamllint@v3"
         with:
           file_or_dir: ".github/"
-          config_file: ".yamllint"
+          config_file: ".yamllint.yml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: "Publish module"
 
 on:
   workflow_dispatch:
-  
+
 jobs:
   create-github-release:
     name: Deploy GitHub Release

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -9,10 +9,12 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-20.04', 'macos-11', 'windows-2019' ]
-        puppet_version: [ '7' ]
+        puppet_version: [ '7', '8' ]
         include:
           - puppet_version: '7'
             ruby: '2.7'
+          - puppet_version: '8'
+            ruby: '3.1'
 
           - os: 'ubuntu-20.04'
             os_type: 'Linux'

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -8,8 +8,8 @@ jobs:
     name: Puppet${{ matrix.puppet_version }} gem on Ruby ${{ matrix.ruby }} on ${{ matrix.os_type }}
     strategy:
       matrix:
-        os: [ 'ubuntu-20.04', 'macos-11', 'windows-2019' ]
-        puppet_version: [ '7', '8' ]
+        os: ['ubuntu-20.04', 'macos-11', 'windows-2019']
+        puppet_version: ['7', '8']
         include:
           - puppet_version: '7'
             ruby: '2.7'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -8,8 +8,8 @@ jobs:
     name: Puppet${{ matrix.puppet_version }} gem on Ruby ${{ matrix.ruby }} on ${{ matrix.os_type }}
     strategy:
       matrix:
-        os: [ 'ubuntu-20.04', 'macos-11', 'windows-2019' ]
-        puppet_version: [ '7' ]
+        os: ['ubuntu-20.04', 'macos-11', 'windows-2019']
+        puppet_version: ['7']
         include:
           - puppet_version: '7'
             ruby: '2.7'


### PR DESCRIPTION
This commit adds units tests running against Puppet 8 nightly gems, running on Ruby 3.1.