### PR TITLE
(maint) Updates Windows nightly tests

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -27,7 +27,11 @@ jobs:
           - os: 'windows-2019'
             os_type: 'Windows'
             env_set_cmd: '$env:'
-            gem_file: 'puppet-latest-x64-mingw32.gem'
+            # setup-ruby uses ucrt for newer Rubies, but we only support mingw
+            # in our Windows Puppet nightly gems. For now, we'll just install
+            # the universal gem and manually install the ffi dependency
+            gem_file: 'puppet-latest.gem'
+            extra_steps: 'gem install ffi --version 1.15.5'
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -41,6 +45,7 @@ jobs:
 
       - name: Install the latest nightly build of puppet${{ matrix.puppet_version }} gem
         run: |
+          ${{ matrix.extra_steps }}
           curl https://nightlies.puppet.com/downloads/gems/puppet${{ matrix.puppet_version }}-nightly/${{ matrix.gem_file }} --output puppet.gem --location
           gem install puppet.gem -N
 


### PR DESCRIPTION
Newer versions of Ruby used by the setup-ruby action use the ucrt C library. Puppet nightly gems are built with the mscvcrt library (AKA mingw), and that mismatch causes installation failures.

This commit updates the GitHub Action that runs module unit tests against nightly Puppet gems to use the generic gem instead of the mingw gem, and adds a step to install the ffi dependency that was included in the mingw gem but not the generic gem.

Originally encountered in https://github.com/puppetlabs/puppetlabs-puppet_agent/commit/476d9b8d8e09024c7e8fbcc251168e81180df4d9