### PR TITLE
(PA-5344) Add Puppet 8 to released gem unit tests

### DIFF
--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -9,10 +9,12 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-20.04', 'macos-11', 'windows-2019']
-        puppet_version: ['7']
+        puppet_version: ['7', '8']
         include:
           - puppet_version: '7'
             ruby: '2.7'
+          - puppet_version: '8'
+            ruby: '3.1'
 
           - os: 'ubuntu-20.04'
             os_type: 'Linux'


### PR DESCRIPTION
Now that Puppet 8.0.0 has been released, this commit adds the released (as opposed to nightly) Puppet 8 gem to unit tests for modules.