### PR TITLE
(maint) Update macOS in tests from 11 to 12

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Puppet${{ matrix.puppet_version }} gem on Ruby ${{ matrix.ruby }} on ${{ matrix.os_type }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'macos-11', 'windows-2019']
+        os: ['ubuntu-20.04', 'macos-12', 'windows-2019']
         puppet_version: ['7', '8']
         include:
           - puppet_version: '7'
@@ -20,7 +20,7 @@ jobs:
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest.gem'
-          - os: 'macos-11'
+          - os: 'macos-12'
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Puppet${{ matrix.puppet_version }} gem on Ruby ${{ matrix.ruby }} on ${{ matrix.os_type }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'macos-11', 'windows-2019']
+        os: ['ubuntu-20.04', 'macos-12', 'windows-2019']
         puppet_version: ['7', '8']
         include:
           - puppet_version: '7'
@@ -18,7 +18,7 @@ jobs:
 
           - os: 'ubuntu-20.04'
             os_type: 'Linux'
-          - os: 'macos-11'
+          - os: 'macos-12'
             os_type: 'macOS'
           - os: 'windows-2019'
             os_type: 'Windows'


### PR DESCRIPTION
macOS 11 (Big Sur) will be end-of-life shortly. This commit updates macOS runners in GitHub Actions from macOS 11 to macOS 12 (Monterey).