### PR TITLE
(PE-36953) Add reusable workflow for exporting GH issues to JIRA

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,0 +1,70 @@
+# This is a reusable workflow[1] to export a github issue to JIRA ticket in
+# response to a label being applied to the issue[2].
+#
+# [1] https://docs.github.com/en/actions/using-workflows/reusing-workflows
+# [2] https://docs.github.com/en/actions/managing-issues-and-pull-requests/commenting-on-an-issue-when-a-label-is-added
+
+on:
+  workflow_call:
+    inputs:
+      jira-project:
+        description: The Jira project in which issues should be created.
+        required: true
+        type: string
+      jira-base-url:
+        description: The base URL for the Jira instance in which to create issues, e.g. https://jira.example.com
+        required: true
+        type: string
+      jira-user-email:
+        description: The email address of the Jira user, e.g. user@example.com
+        required: true
+        type: string
+    secrets:
+      jira-api-token:
+        description: An API token needed to create issues in Jira
+        required: true
+
+name: Export to JIRA
+
+jobs:
+  export:
+    if: ${{ github.repository_owner == 'puppetlabs' && github.event.label.name == 'triaged' }}
+    runs-on: ubuntu-latest
+    name: Export to JIRA
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: 'Migrated issue to '
+
+      - name: Login
+        if: steps.fc.outputs.comment-id == ''
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ inputs.jira-base-url }}
+          JIRA_USER_EMAIL: ${{ inputs.jira-user-email }}
+          JIRA_API_TOKEN: ${{ secrets.jira-api-token }}
+
+      - name: Create Issue
+        if: steps.fc.outputs.comment-id == ''
+        id: create
+        uses: atlassian/gajira-create@v3
+        with:
+          project: ${{ inputs.jira-project }}
+          issuetype: Bug
+          summary: ${{ github.event.issue.title }}
+          description: |
+            Originally reported in ${{ github.event.issue.html_url }}
+
+            ${{ github.event.issue.body }}
+
+      - name: Create Comment
+        if: steps.fc.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Migrated issue to [${{ steps.create.outputs.issue }}](${{ inputs.jira-base-url }}/browse/${{ steps.create.outputs.issue }})


### PR DESCRIPTION
This commit defines a reusable workflow to export a GH issue to JIRA in response
to a `triaged` label being applied to the issue.

The workflow is idempotent, so that if `triaged` label is removed and readded,
then we won't create another JIRA issue. Idempotency is implemented by checking
to see if the `github-actions[bot]` already added a comment with specific text.

Otherwise, the `github-actions[bot]` uses the `jira-api-token` secret to log
into JIRA and create an issue. The `jira-base-url`, `jira-user-email` and
`jira-project` variables must also be specified. The action adds a comment to
the GH issue with the URL of the newly created JIRA ticket.

    Migrated issue to [FACT-XXX]($JIRA_BASE_URL/browse/FACT-XXX)

The newly created JIRA ticket includes a reference back to the originating GH
issue:

    Originally reported in https://github.com/puppetlabs/<project>/issues/<id>

This workflow should be called from another workflow, for example, for facter:

    on:
      issues:
        types: [labeled]

    permissions:
      issues: write

    jobs:
      export:
        uses: "puppetlabs/phoenix-github-actions/.github/workflows/jira.yml@main"
        with:
          jira-project: FACT
          jira-base-url: ${{ vars.JIRA_BASE_URL }}
          jira-user-email: ${{ vars.JIRA_USER_EMAIL }}
        secrets:
          jira-api-token: ${{ secrets.JIRA_ISSUES_ACTION }}

The outer workflow must declare that it requires `write` permission to issues so
that the reusable workflow can add a comment.

Only users with `triage` github permission are allowed to apply (and dismiss) labels to
issues, so we don't need to worry about random users creating JIRA tickets.
