### PR TITLE
Use pandoc to convert GFM to JIRA wiki format

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -36,11 +36,36 @@ jobs:
         uses: peter-evans/find-comment@v2
         id: fc
         with:
+          # Authenticates using GITHUB_TOKEN
           issue-number: ${{ github.event.issue.number }}
           comment-author: 'github-actions[bot]'
           body-includes: 'Migrated issue to '
 
-      - name: Login
+      - name: Save markdown
+        if: steps.fc.outputs.comment-id == ''
+        uses: DamianReeves/write-file-action@v1.2
+        with:
+          path: body.md
+          contents: ${{ github.event.issue.body }}
+
+      - name: Convert markdown to jira wiki format
+        if: steps.fc.outputs.comment-id == ''
+        # There is a pandoc docker image, but the workflow will always pull
+        # the image even if this step is a noop, so install the package
+        run: |
+          sudo apt-get install -y pandoc
+          pandoc --standalone --from markdown --to jira --output body.jira body.md
+          printf "Originally reported in %s\n\n" "${{ github.event.issue.html_url }}" > description.jira
+          cat body.jira >> description.jira
+
+      - name: Read JIRA issue description
+        if: steps.fc.outputs.comment-id == ''
+        id: description
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: description.jira
+
+      - name: Login to JIRA
         if: steps.fc.outputs.comment-id == ''
         uses: atlassian/gajira-login@v3
         env:
@@ -48,7 +73,7 @@ jobs:
           JIRA_USER_EMAIL: ${{ inputs.jira-user-email }}
           JIRA_API_TOKEN: ${{ secrets.jira-api-token }}
 
-      - name: Create Issue
+      - name: Create JIRA issue
         if: steps.fc.outputs.comment-id == ''
         id: create
         uses: atlassian/gajira-create@v3
@@ -56,15 +81,13 @@ jobs:
           project: ${{ inputs.jira-project }}
           issuetype: Bug
           summary: ${{ github.event.issue.title }}
-          description: |
-            Originally reported in ${{ github.event.issue.html_url }}
-
-            ${{ github.event.issue.body }}
+          description: "${{ steps.description.outputs.content }}"
 
       - name: Create Comment
         if: steps.fc.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v3
         with:
+          # authenticates using GITHUB_TOKEN
           issue-number: ${{ github.event.issue.number }}
           body: |
             Migrated issue to [${{ steps.create.outputs.issue }}](${{ inputs.jira-base-url }}/browse/${{ steps.create.outputs.issue }})


### PR DESCRIPTION
Although the JIRA Cloud UI accepts Github Flavored Markdown (GFM), it autoconverts to Atlassian Document Format (ADF). The same functionality is not available in JIRA's v2 or v3 REST API. So any markdown in a github issue did not render correctly when displayed in JIRA.

This commit uses pandoc to convert from GFM to JIRA formats.

Since the github issue description may contain unsafe shell characters, we use actions to read & write the description. This avoids having to read file contents into an environment variable and trying to pass the multiline value to the next step[1].

[1] https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string