### PR TITLE
(PA-5872) Create reusable workflow to import issues

### DIFF
--- a/.github/actions/import_from_jira.rb
+++ b/.github/actions/import_from_jira.rb
@@ -1,0 +1,141 @@
+require 'json'
+require 'shellwords'
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+
+  gem 'jira-ruby'
+  gem 'pandoc-ruby'
+end
+
+class ExportIssue
+  JIRA_URL = ENV['JIRA_BASE_URL']
+
+  # JIRA statuses for closed tickets
+  CLOSED = Set.new(%w[Cancelled Closed]).freeze
+
+  # Only query the fields we need to reduce amount of data that we fetch
+  FIELDS = %i[
+    key
+    issuetype
+    summary
+    description
+    status
+    resolution
+    created
+  ].freeze
+
+  def initialize
+    options = {
+      site: JIRA_URL,
+      context_path: '',
+      auth_type: :basic,
+      username: ENV['JIRA_USER_EMAIL'],
+      password: ENV['JIRA_API_TOKEN']
+    }
+
+    @client = JIRA::Client.new(options)
+  end
+
+  def export(key)
+    raise ArgumentError, "Invalid JIRA key '#{key}'" unless key.match?('[A-Z]+-[0-9]+')
+
+    puts "Exporting '#{key}'"
+
+    # This raises if the key doesn't exist
+    issue = @client.Issue.jql("key = #{key}", fields: FIELDS, max_results: 1).first
+
+    gh = transform(issue)
+    labels = gh["labels"].join(',')
+
+    Tempfile.create do |f|
+      f.write(gh["body"])
+      f.flush
+
+      output = %x{gh issue create --title #{Shellwords.escape(gh["title"])} --body-file #{f.path} --label #{labels}}
+      if $? != 0
+        puts "Failed to create issue"
+        puts
+        puts output
+        exit(1)
+      end
+
+      data = output.match(%r{^https://github.com/.*$})
+      unless data
+        puts "Failed to match github URL"
+        puts
+        puts output
+        exit(1)
+      end
+
+      url = data[0]
+      puts "Created issue: #{url}"
+
+      if gh["closed"]
+        output = %x{gh issue close #{url}}
+        if $? != 0
+          puts "Failed to close issue"
+          puts
+          puts output
+          exit(1)
+        end
+
+        puts "Closed issue: #{url}"
+      end
+
+      # Add comment
+      comment = issue.comments.build
+      comment.save!(body: "Migrated issue to #{url}")
+    end
+  end
+
+  private
+
+  def transform(issue)
+    created = DateTime.parse(issue.created).strftime('%F %r')
+    title = "(#{issue.key}) #{issue.summary}"
+    body = <<~END
+    This issue was originally created on #{created} in #{JIRA_URL}/browse/#{CGI.escapeHTML(issue.key)}
+
+    #{markdownify(issue.description)}
+    END
+
+    labels = ['from-jira']
+    case issue.issuetype.name
+    when 'Bug'
+      labels << 'bug'
+    when 'Story'
+      labels << 'enhancement'
+    else
+      # ignore tasks, epics
+    end
+
+    if issue.status.name == 'Cancelled'
+      case issue.resolution["name"]
+      when 'Duplicate'
+        labels << 'duplicate'
+      when 'Incomplete', 'Declined', "Won't Do", "Won't Fix"
+        labels << 'wontfix'
+      else
+        # ignore
+      end
+    end
+
+    {
+      'title' => title,
+      'body' => body,
+      'labels' => labels,
+      'closed' => CLOSED.include?(issue.status.name)
+    }
+  end
+
+  def markdownify(text)
+    return '' unless text
+
+    PandocRuby.convert(text, from: :jira, to: :gfm)
+  end
+end
+
+exporter = ExportIssue.new
+exporter.export(ARGV[0])

--- a/.github/workflows/import_from_jira.yml
+++ b/.github/workflows/import_from_jira.yml
@@ -1,0 +1,57 @@
+---
+name: Import GitHub Issue from JIRA
+
+on:
+  workflow_call:
+    inputs:
+      jira-key:
+        description: The JIRA issue key, e.g. PUP-123
+        required: true
+        type: string
+      jira-base-url:
+        description: The base URL for the Jira instance in which to create issues, e.g. https://jira.example.com
+        required: true
+        type: string
+      jira-user-email:
+        description: The email address of the Jira user, e.g. user@example.com
+        required: true
+        type: string
+    secrets:
+      jira-api-token:
+        description: An API token needed to read issues in Jira
+        required: true
+
+jobs:
+  import:
+    if: ${{ github.repository_owner == 'puppetlabs' }}
+    runs-on: ubuntu-latest
+    name: Import from JIRA
+    steps:
+      - name: Checkout current branch of caller's repo
+        uses: actions/checkout@v4
+
+        # This is a hack to "reuse" the ruby script defined in the *this* reusable workflow
+        # I tried checking out *this* repo, but github seems to only clone `.github/workflows`
+        # but not files in `.github` or `.github/actions`.
+      - name: Get action script
+        run: |
+          gh api "${{ github.api_url }}/repos/puppetlabs/phoenix-github-actions/contents/.github/actions/import_from_jira.rb" -H "Accept: application/vnd.github.raw" > import_from_jira.rb
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Install Ruby 3.2
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install Pandoc
+        run: |
+          sudo apt install pandoc
+
+      - run: |
+          ruby import_from_jira.rb ${{ inputs.jira-key }}
+        env:
+          JIRA_BASE_URL: ${{ inputs.jira-base-url }}
+          JIRA_USER_EMAIL: ${{ inputs.jira-user-email }}
+          JIRA_API_TOKEN: ${{ secrets.jira-api-token }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Creates a reusable workflow to import a single issue from Jira to GitHub.

The caller workflow must pass 4 inputs:

    jira-key
    jira-base-url
    jira-user-email
    jira-api-token

The first input is the issue to import, e.g. PUP-123. The other 3 inputs are the same as what's used in the workflow that exports issues from GitHub to Jira.

This workflow executes a ruby script that relies on the `jira-ruby` gem, `pandoc` executable (to convert Jira wiki to GFM) and the `gh` CLI. The latter is "preinstalled on all GitHub-hosted runners"[1]

[1] https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows