### PR TITLE
(maint) Port static code analysis

### DIFF
--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -1,0 +1,41 @@
+---
+name: Static Code Analysis
+
+on: workflow_call
+
+jobs:
+  static_code_analysis:
+    name: Run checks
+
+    env:
+      ruby_version: '3.0'
+      extra_checks: check:symlinks check:git_ignore check:dot_underscore check:test_file
+
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout current PR code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install ruby version ${{ env.ruby_version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.ruby_version }}
+
+      - name: Prepare testing environment with bundler
+        run: |
+          git config --global core.longpaths true
+          bundle update --jobs 4 --retry 3
+
+      - name: Run rubocop check
+        run: bundle exec rake ${{ env.extra_checks }} rubocop
+
+      - name: Run syntax check
+        run: bundle exec rake ${{ env.extra_checks }} syntax syntax:hiera syntax:manifests syntax:templates
+
+      - name: Run lint check
+        run: bundle exec rake ${{ env.extra_checks }} lint
+
+      - name: Run metadata_lint check
+        run: bundle exec rake ${{ env.extra_checks }} metadata_lint


### PR DESCRIPTION
This commits adds the static code analysis workflow found in core modules.

There are a few differences between this version and what is currently used:

- Updates Ruby version from the long-EOL 2.6 to 3.0.
- Updates GitHub Actions runner from Ubuntu 20.04 to ubuntu-latest.
- Removes commit check Rake task.
- No longer configures Bundler to ignore the non-existent "release" group in a Gemfile.