### PR TITLE
(PA-5940) Allow Jira issues to be created from pull requests

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -37,7 +37,7 @@ jobs:
         id: fc
         with:
           # Authenticates using GITHUB_TOKEN
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ github.event.issue.number || github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: 'Migrated issue to '
 
@@ -46,7 +46,7 @@ jobs:
         uses: DamianReeves/write-file-action@v1.2
         with:
           path: body.md
-          contents: ${{ github.event.issue.body }}
+          contents: ${{ github.event.issue.body || github.event.pull_request.body || 'See GitHub for details'}}
 
       - name: Convert markdown to jira wiki format
         if: steps.fc.outputs.comment-id == ''
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo apt-get install -y pandoc
           pandoc --standalone --from markdown --to jira --output body.jira body.md
-          printf "Originally reported in %s\n\n" "${{ github.event.issue.html_url }}" > description.jira
+          printf "Originally reported in %s\n\n" "${{ github.event.issue.html_url || github.event.pull_request.html_url }}" > description.jira
           cat body.jira >> description.jira
 
       - name: Read JIRA issue description
@@ -80,7 +80,7 @@ jobs:
         with:
           project: ${{ inputs.jira-project }}
           issuetype: Bug
-          summary: ${{ github.event.issue.title }}
+          summary: ${{ github.event.issue.title || github.event.pull_request.title }}
           description: "${{ steps.description.outputs.content }}"
 
       - name: Create Comment
@@ -88,6 +88,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@v3
         with:
           # authenticates using GITHUB_TOKEN
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ github.event.issue.number || github.event.pull_request.number }}
           body: |
             Migrated issue to [${{ steps.create.outputs.issue }}](${{ inputs.jira-base-url }}/browse/${{ steps.create.outputs.issue }})


### PR DESCRIPTION
This commit makes it possible to apply a label to a pull request and have it create a JIRA ticket, just like it does for issues.. In order to use this, the calling workflow must specify (note the differences in underscore vs dash):

    on:
     pull_requests:
       types: [labeled]
    permissions:
      pull-requests: write

When a label is applied to an issue or pull request, GitHub triggers the workflow with a `labeled` event and either a github.event.issue[1] or github.event.pull_request[2] payload, respectively. So this PR checks for either the issue or pull_request as the payload.

If the workflow is trigged due to a pull request, then `github.event.issue.number` will safely evaluate to null. In other words, we don't need to write `(github.event.issue && github.event.issue.number) || ...`

If a PR is submitted with an empty body, then provide a default message, otherwise the `write-file-action` will error with:

    Error: Input required and not supplied: contents

[1] https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=labeled#issue
[2] https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=labeled#pull_request