### PR TITLE
Bump static code Ruby to 3.1

### DIFF
--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Run checks
 
     env:
-      ruby_version: '3.0'
+      ruby_version: '3.1'
       extra_checks: check:symlinks check:git_ignore check:dot_underscore check:test_file
 
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
Ruby 3.0 will be end-of-life next month. This commit updates the Ruby used in the static code analysis workflow from 3.0 to 3.1.