### PR TITLE
Unit test updates

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -29,9 +29,10 @@ jobs:
             env_set_cmd: '$env:'
             # setup-ruby uses ucrt for newer Rubies, but we only support mingw
             # in our Windows Puppet nightly gems. For now, we'll just install
-            # the universal gem and manually install the ffi dependency
+            # the universal gem and manually install the ffi dependency.
+            # Use the latest known good version of the ffi gem.
             gem_file: 'puppet-latest.gem'
-            extra_steps: 'gem install ffi --version 1.15.5'
+            extra_steps: 'gem install ffi --version 1.16.3'
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -34,13 +34,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: Prepare testing environment with bundler
-        run: |
-          git config --global core.longpaths true
-          bundle config set system 'true'
-          bundle config set --local without 'release'
-          bundle update --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Run unit tests
         run: bundle exec rake parallel_spec


### PR DESCRIPTION
This PR updates the setup-ruby action to use bundler-cache (as first implemented in Puppet [here](https://github.com/puppetlabs/puppet/commit/86820eee25e428f7e667bf9529b97c32e6575d9b)) and updates the FFI gem to the latest known good version.