### PR TITLE
macOS 12 is no longer supported, use latest

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Puppet${{ matrix.puppet_version }} gem on Ruby ${{ matrix.ruby }} on ${{ matrix.os_type }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'macos-12', 'windows-2019']
+        os: ['ubuntu-20.04', 'macos-latest', 'windows-2019']
         puppet_version: ['7', '8']
         include:
           - puppet_version: '7'
@@ -20,7 +20,7 @@ jobs:
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest.gem'
-          - os: 'macos-12'
+          - os: 'macos-latest'
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Puppet${{ matrix.puppet_version }} gem on Ruby ${{ matrix.ruby }} on ${{ matrix.os_type }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'macos-12', 'windows-2019']
+        os: ['ubuntu-20.04', 'macos-latest', 'windows-2019']
         puppet_version: ['7', '8']
         include:
           - puppet_version: '7'
@@ -18,7 +18,7 @@ jobs:
 
           - os: 'ubuntu-20.04'
             os_type: 'Linux'
-          - os: 'macos-12'
+          - os: 'macos-latest'
             os_type: 'macOS'
           - os: 'windows-2019'
             os_type: 'Windows'


### PR DESCRIPTION
We're using latest, because macOS releases frequently.

https://github.com/actions/runner-images/issues/10721