### PR TITLE
(maint) Update windows action runner image to windows-2022

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Puppet${{ matrix.puppet_version }} gem on Ruby ${{ matrix.ruby }} on ${{ matrix.os_type }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-2019']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-2022']
         puppet_version: ['7', '8']
         include:
           - puppet_version: '7'
@@ -24,7 +24,7 @@ jobs:
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'
-          - os: 'windows-2019'
+          - os: 'windows-2022'
             os_type: 'Windows'
             env_set_cmd: '$env:'
             # setup-ruby uses ucrt for newer Rubies, but we only support mingw

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Puppet${{ matrix.puppet_version }} gem on Ruby ${{ matrix.ruby }} on ${{ matrix.os_type }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-2019']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-2022']
         puppet_version: ['7', '8']
         include:
           - puppet_version: '7'
@@ -20,7 +20,7 @@ jobs:
             os_type: 'Linux'
           - os: 'macos-latest'
             os_type: 'macOS'
-          - os: 'windows-2019'
+          - os: 'windows-2022'
             os_type: 'Windows'
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The Windows 2019 image will be removed on 2025-06-30 and is currently in a brownout period. For more details, see
https://github.com/actions/runner-images/issues/12045.

Due to this, this commit updates the unit test workflows to use the windows-2022 runner image instead of windows-2019. windows-2022 was chosen instead of windows-2025 because it's a supported platform for both Puppet 7 and 8.