### PR TITLE
Use multi_json 1.15.0 only for ruby 2.7

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -48,6 +48,9 @@ jobs:
         run: |
           ${{ matrix.extra_steps }}
           curl https://nightlies.puppet.com/downloads/gems/puppet${{ matrix.puppet_version }}-nightly/${{ matrix.gem_file }} --output puppet.gem --location
+          if [[ ${{ matrix.ruby }} == "2.7" ]]; then
+            gem install multi_json -v 1.15.0
+          fi
           gem install puppet.gem -N
 
       - name: Prepare testing environment with bundler


### PR DESCRIPTION
An update to multi_json 1.16.0 specified ruby > 3.2; this started failing on ubuntu vms, probably a bug with the "only install gem dependencies that satisfy the currently running ruby" in ruby < 3.x. This change forces 1.15.0 to be installed first, which ruby will then use for the installation of puppet itself.