### PR TITLE
(maint) Use multi_json 1.15.0 only for ruby 2.7

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -44,13 +44,14 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
 
+      - name: Install multijson 1.15.0
+        if: startsWith(matrix.ruby, '2.7')
+        run: gem install multijson -v 1.15.0
+
       - name: Install the latest nightly build of puppet${{ matrix.puppet_version }} gem
         run: |
           ${{ matrix.extra_steps }}
           curl https://nightlies.puppet.com/downloads/gems/puppet${{ matrix.puppet_version }}-nightly/${{ matrix.gem_file }} --output puppet.gem --location
-          if [[ ${{ matrix.ruby }} == "2.7" ]]; then
-            gem install multi_json -v 1.15.0
-          fi
           gem install puppet.gem -N
 
       - name: Prepare testing environment with bundler


### PR DESCRIPTION
This PR fixes error on windows when trying to install `multi_json`

https://github.com/puppetlabs/puppetlabs-puppet_agent/actions/runs/16194278391/job/45776192718#step:4:34