### PR TITLE
Install released gems

### DIFF
--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -1,7 +1,11 @@
 ---
 name: Unit Tests with released Puppet gem
 
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      PUPPET_FORGE_TOKEN_PUBLIC:
+        required: true
 
 jobs:
   unit_tests_with_released_puppet_gem:
@@ -25,7 +29,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     env:
-      PUPPET_GEM_VERSION: ~> ${{ matrix.puppet_version }}.0
+      PUPPET_GEM_VERSION: "source:https://rubygems-puppetcore.puppet.com#~> ${{ matrix.puppet_version }}.0"
     steps:
       - name: Checkout current PR code
         uses: actions/checkout@v4
@@ -35,6 +39,11 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+        env:
+          BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: forge-key:${{ secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
+
+      - name: List gems
+        run: cat Gemfile.lock
 
       - name: Run unit tests
         run: bundle exec rake parallel_spec


### PR DESCRIPTION
This makes it possible to install puppet and facter from the rubygesm-puppetcore server, while still using rubygems.org for everything else.

The `setup-ruby` action with `bundler-cache: true` will perform a bundle install, so we need to make the credentials available to the action.

This also adds a step to list installed gems to verify the expected gems are installed.

There is a cron module PR to call this new shared action. https://github.com/puppetlabs/puppetlabs-cron_core/pull/80

I also simulated what would happen when this PR is merged to `main` and is called by someone else with access to the secret. Note puppet and facter versions when testing last released puppet [7.x](https://github.com/puppetlabs/phoenix-test-gha/actions/runs/16307212595/job/46055735965#step:4:13) and [8.x](https://github.com/puppetlabs/phoenix-test-gha/actions/runs/16307212595/job/46055735968#step:4:13)
