### PR TITLE
(maint) Use null value with Puppet 7

### DIFF
--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -17,7 +17,7 @@ jobs:
         include:
           - puppet_version: '7'
             ruby: '2.7'
-            puppet_forge_token: ''
+            puppet_forge_token: ${{ null }}
           - puppet_version: '8'
             ruby: '3.1'
             puppet_forge_token: 'YES'


### PR DESCRIPTION
Previously, in using the unit test workflows with Puppet modules, we set Puppet 7's PUPPET_FORGE_TOKEN environment variable to '' and in module Gemfiles evaluated `!ENV['PUPPET_FORGE_TOKEN'].to_s.empty?`.

However, the latest PDK template's (3.5.1) Gemfile evaluates the PUPPET_FORGE_TOKEN environment variable slightly differently, opting instead to check whether it exists at all:

https://github.com/puppetlabs/pdk-templates/blob/3.5.1.2/moduleroot/Gemfile.erb#L63

Ruby confusingly evaluates everything besides false and nil as "truthy," so an empty string (like the one we set for PUPPET_FORGE_TOKEN) is evaluated as true.

This commit updates Puppet 7's environment variable to be set to null instead of an empty string to allow the workflow to be used with PDK template 3.5.1