### PR TITLE
(maint) Install Puppet 7 from Puppet Core

### DIFF
--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -17,10 +17,8 @@ jobs:
         include:
           - puppet_version: '7'
             ruby: '2.7'
-            puppet_forge_token: ${{ null }}
           - puppet_version: '8'
             ruby: '3.1'
-            puppet_forge_token: 'YES'
 
           - os: 'ubuntu-latest'
             os_type: 'Linux'
@@ -46,8 +44,8 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
         env:
-          BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: forge-key:${{ matrix.puppet_version != '7' && secrets.PUPPET_FORGE_TOKEN_PUBLIC || '' }}
-          PUPPET_FORGE_TOKEN: ${{ matrix.puppet_forge_token }}
+          BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: forge-key:${{ secrets.PUPPET_FORGE_TOKEN_PUBLIC || '' }}
+          PUPPET_FORGE_TOKEN: 'YES'
 
       - name: Run unit tests
         run: bundle exec rake parallel_spec


### PR DESCRIPTION
Currently, Phoenix modules install Puppet 8 gems from Puppet Core, but Puppet 7 gems from Rubygems. The logic currently used in Phoenix module gemfiles to determine whether to install from Puppet Core differs slightly from that used in the latest PDK (3.5.1) template, causing authentication errors when attempting to install Puppet 7 gems.

The current workflow with the new PDK 3.5.1 gemfile logic attempts to install Puppet 7 gems from Puppet Core without passing on the proper credentials.

I attempted to bridge the gap with 1499ab9, but I misunderstood how Ruby ingested variables from GitHub Actions.

This commit updates unit tests with released Puppet gems to use Puppet Core gems for Puppet 7.