### PR TITLE
(maint) set forge token globally

### DIFF
--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -10,6 +10,7 @@ jobs:
     env:
       ruby_version: '3.1'
       extra_checks: check:symlinks check:git_ignore check:dot_underscore check:test_file
+      PUPPET_FORGE_TOKEN: 'YES'
 
     runs-on: 'ubuntu-latest'
     steps:
@@ -25,7 +26,6 @@ jobs:
           bundler-cache: true
         env:
           BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM: forge-key:${{ secrets.PUPPET_FORGE_TOKEN_PUBLIC }}
-          PUPPET_FORGE_TOKEN: 'YES'
 
       - name: Run rubocop check
         run: bundle exec rake ${{ env.extra_checks }} rubocop


### PR DESCRIPTION
When using the static analysis workflow, the dependencies are re-evaluated and subsequent `bundle exec` calls will not produce the same dependency results based on the usage of the PUPPET_FORGE_TOKEN. This change sets it globally so the dependencies are always evaluated to the same result.