### PR TITLE
(maint) Specify PUPPET_FORGE_TOKEN for test execution

### DIFF
--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -49,3 +49,5 @@ jobs:
 
       - name: Run unit tests
         run: bundle exec rake parallel_spec
+        env:
+          PUPPET_FORGE_TOKEN: 'YES'


### PR DESCRIPTION
Running `bundle exec` needs to resolve gems the same way that they resolve when installing gems.