### PR TITLE
(maint) Revert Ruby bump

### DIFF
--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Run checks
 
     env:
-      ruby_version: '3.3'
+      ruby_version: '3.1'
       extra_checks: check:symlinks check:git_ignore check:dot_underscore check:test_file
       PUPPET_FORGE_TOKEN: 'YES'
 


### PR DESCRIPTION
This commit reverts the Ruby bump from e9d5634, as it is causing unexpected dependency failures in projects. This should be resolved once https://github.com/puppetlabs/vmfloaty/pull/254 is merged and a new release of the vmfloaty gem is cut.