### PR TITLE
(maint) Update Ruby, install cURL

### DIFF
--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Run checks
 
     env:
-      ruby_version: '3.1'
+      ruby_version: '3.3'
       extra_checks: check:symlinks check:git_ignore check:dot_underscore check:test_file
       PUPPET_FORGE_TOKEN: 'YES'
 
@@ -18,6 +18,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      # Patron, which is a transitive dependency of beaker-abs and Bolt, requires cURL libraries
+      - name: Install cURL
+        run: sudo apt install -y curl
 
       - name: Install ruby version ${{ env.ruby_version }}
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Newer versions of Patron, which is a gem that's a transitive dependency of beaker-abs and Bolt (which are common in many Puppet-related Gemfiles), require cURL libraries to build native extensions.

This commit installs cURL on GitHub Actions runners that run static code analysis.