### PR TITLE
(maint) Install cURL development files

### DIFF
--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -20,8 +20,8 @@ jobs:
           fetch-depth: 0
 
       # Patron, which is a transitive dependency of beaker-abs and Bolt, requires cURL libraries
-      - name: Install cURL
-        run: sudo apt install -y curl
+      - name: Install cURL development files
+        run: sudo apt install -y libcurl4-openssl-dev
 
       - name: Install ruby version ${{ env.ruby_version }}
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
The container image we're using for this action already has cURL installed; Patron is looking for the development files, which are included in a separate package.