### PR TITLE
(PA-7824) Use latest puppet_litmus, Bolt

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -56,6 +56,7 @@ jobs:
       - name: Prepare testing environment with bundler
         env:
           GEM_SOURCE: "https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/"
+          PUPPET_FORGE_TOKEN: 'YES'
         run: |
           git config --global core.longpaths true
           bundle config set system 'true'


### PR DESCRIPTION
The puppet_litmus gem, which pulls in dependencies such as Bolt, uses the PUPPET_FORGE_TOKEN env var to determine what version to resolve to. We want the latest version, so this commit sets PUPPET_FORGE_TOKEN