### PR TITLE
Run apt-get update

### DIFF
--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -21,7 +21,9 @@ jobs:
 
       # Patron, which is a transitive dependency of beaker-abs and Bolt, requires cURL libraries
       - name: Install cURL development files
-        run: sudo apt install -y libcurl4-openssl-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
 
       - name: Install ruby version ${{ env.ruby_version }}
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
If the apt cache is stale on the GitHub runner, then it may fail to install

    Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
    Ign:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.8
    Ign:2 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.8
    Ign:2 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.8
    Err:2 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libcurl4-openssl-dev amd64 8.5.0-2ubuntu10.8
      404  Not Found [IP: 52.154.174.208 80]
    E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/c/curl/libcurl4-openssl-dev_8.5.0-2ubuntu10.8_amd64.deb  404  Not Found [IP:52.154.174.208 80]
    E: Unable to fetch some archives, maybe run apt-get update or try with
    --fix-missing?

Also use `apt-get` instead of `apt` as the former is recommending for scripting, while the latter prints:

    WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

This should resolve https://github.com/puppetlabs/puppetlabs-puppet_agent/actions/runs/25466905679/job/74722129244