### PR TITLE
(PA-8445) Pull released Facter from Artifactory

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -51,7 +51,7 @@ jobs:
         run: |
           ${{ matrix.extra_steps }}
           curl https://artifactory.delivery.puppetlabs.net/artifactory/internal_nightly__local/downloads/gems/puppet${{ matrix.puppet_version }}-nightly/${{ matrix.gem_file }} --output puppet.gem --location
-          gem install puppet.gem -N
+          gem install puppet.gem -N --source https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/
 
       - name: Prepare testing environment with bundler
         env:


### PR DESCRIPTION
## Summary

Adds `--source <artifactory-rubygems-mirror>` to `gem install puppet.gem` in the shared `unit_tests_with_nightly_puppet_gem.yaml` workflow so Puppet's Facter runtime dependency is resolved from the Artifactory proxy of Puppet Core (latest released Facter) instead of public rubygems.org (stuck on Facter 4.10.0).

## Why

Without the source flag, RubyGems falls back to public rubygems.org for transitive deps. The latest Facter on public rubygems is 4.10.0, several versions behind the current released Facter on Puppet Core. The Artifactory mirror at `artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/` is the same URL the next bundler step already uses for `GEM_SOURCE`, so the source choice is consistent across the job.

Jira: [PA-8445](https://perforce.atlassian.net/browse/PA-8445)

## Test plan
- [ ] yamllint passes on the workflow file
- [ ] Downstream module CI consuming this reusable workflow installs Facter from the Artifactory mirror at a version > 4.10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)