### PR TITLE
(PA-8445) Use Artifactory as sole gem source

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -51,7 +51,9 @@ jobs:
         run: |
           ${{ matrix.extra_steps }}
           curl https://artifactory.delivery.puppetlabs.net/artifactory/internal_nightly__local/downloads/gems/puppet${{ matrix.puppet_version }}-nightly/${{ matrix.gem_file }} --output puppet.gem --location
-          gem install puppet.gem -N --source https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/
+          gem sources --add https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/
+          gem sources --remove https://rubygems.org/
+          gem install puppet.gem -N
 
       - name: Prepare testing environment with bundler
         env:


### PR DESCRIPTION
Prior to this, our internal Artifactory mirror, which hosts Puppet Core releases, was added as a gem source, but came after the default location of rubygems.org.

This commit updates the nightly gem test workflow to add Artifactory and remove rubygems.org in order to make sure that the Puppet nightly gem correctly installs the latest Facter as its dependency from Artifactory instead of the outdated last publicly-released Facter from rubygems.org.